### PR TITLE
Configure github pages site

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Add `enablement: true` to `configure-pages` action to automatically enable GitHub Pages and resolve the "Not Found" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d21e22a0-2e27-48c4-9dc0-413c3c7637ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d21e22a0-2e27-48c4-9dc0-413c3c7637ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

